### PR TITLE
サインアップ時のUserDaoを作成しました。

### DIFF
--- a/src/app/Dao/UserDao.php
+++ b/src/app/Dao/UserDao.php
@@ -1,0 +1,52 @@
+<?php
+namespace App\Dao;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use PDO;
+
+/**
+ * ユーザーテーブル用のDao
+ */
+final class UserDao
+{
+    /**
+     * @var PDO
+     */
+    private $pdo;
+
+    /**
+     * コンストラクタ
+     *
+     * @param PDO $pdo
+     */
+    public function __construct()
+    {
+      $this->pdo = new PDO("mysql:host=mysql; dbname=kakeibo; charset=utf8", "root", "password");
+    }
+
+    /**
+     * @return array $user
+     */
+    public function fetchUserByEmail(string $email): ?array
+    {
+      $sql = 'SELECT * FROM users WHERE email = :email';
+      $statement = $this->pdo->prepare($sql);
+      $statement->bindValue(':email', $email, PDO::PARAM_STR);
+      $statement->execute();
+      $user = $statement->fetch(PDO::FETCH_ASSOC);
+
+      return $user ? $user : null;
+    }
+
+    public function createUserAccount(string $email, string $password): void
+    {
+      $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+      $sql = 'INSERT INTO users(email, password) VALUES (:email, :password)';
+      $statement = $this->pdo->prepare($sql);
+      $statement->bindValue(':email', $email, PDO::PARAM_STR);
+      $statement->bindValue(':password', $hashedPassword, PDO::PARAM_STR);
+      $statement->execute();
+      
+    }
+}

--- a/src/public/incomes/index.php
+++ b/src/public/incomes/index.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 if (!isset($_SESSION['user']['id'])) {
-    header('Location: ./signin.php');
+    header('Location: ./users/signin.php');
     exit();
 }
 
@@ -134,11 +134,11 @@ $incomeSources = $statementIncomeSources->fetchAll(PDO::FETCH_ASSOC);
               <option value=""></option>
               <?php foreach ($incomeSources as $incomeSource): ?>
               <option value=<?php echo $incomeSource['id']; ?> <?php if (
-     isset($incomeSourceId) &&
-     $incomeSource['id'] == $incomeSourceId
- ) {
-     echo 'selected';
- } ?>><?php echo $incomeSource['name']; ?></option>
+    isset($incomeSourceId) &&
+    $incomeSource['id'] == $incomeSourceId
+) {
+    echo 'selected';
+} ?>><?php echo $incomeSource['name']; ?></option>
               <?php endforeach; ?>
             </select>
             日付:

--- a/src/public/users/signup_complete.php
+++ b/src/public/users/signup_complete.php
@@ -1,4 +1,9 @@
 <?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Dao\UserDao;
+
 $email = filter_input(INPUT_POST, 'email');
 $password = filter_input(INPUT_POST, 'password');
 $confirmPassword = filter_input(INPUT_POST, 'confirmPassword');
@@ -7,37 +12,30 @@ session_start();
 if (empty($email) || empty($password) || empty($confirmPassword)) {
     $_SESSION['error'] = 'パスワードとメールアドレスを入力してください';
     $_SESSION['formInputs']['email'] = $email;
-    header("Location: ./signup.php");
-    exit;
+    header('Location: ./signup.php');
+    exit();
 }
 
 if ($password !== $confirmPassword) {
     $_SESSION['error'] = 'パスワードが一致しません';
     $_SESSION['formInputs']['email'] = $email;
-    header("Location: ./signup.php");
-    exit;
+    header('Location: ./signup.php');
+    exit();
 }
 
-$pdo = new PDO("mysql:host=mysql; dbname=kakeibo; charset=utf8", "root", "password");
-$sql = 'SELECT * FROM users WHERE email = :email';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':email', $email, PDO::PARAM_STR);
-$statement->execute();
-$user = $statement->fetch(PDO::FETCH_ASSOC);
+$userDao = new UserDao();
+$user = $userDao->fetchUserByEmail($email);
+
 if ($user) {
     $_SESSION['error'] = 'すでに登録済みのメールアドレスです';
     $_SESSION['formInputs']['email'] = $email;
-    header("Location: ./signup.php");
-    exit;
+    header('Location: ./signup.php');
+    exit();
 }
 
-$hashedPassword = password_hash($password, PASSWORD_DEFAULT);
-$sql = "INSERT INTO users(email, password) VALUES (:email, :password)";
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':email', $email, PDO::PARAM_STR);
-$statement->bindValue(':password', $hashedPassword, PDO::PARAM_STR);
-$statement->execute();
+$userDao = new UserDao();
+$userDao->createUserAccount($email, $password);
 $_SESSION['completedMessage'] = '登録が完了しました';
-header("Location: ./signin.php");
-exit;
+header('Location: ./signin.php');
+exit();
 ?>


### PR DESCRIPTION
## 作業対象
[サインアップ完了後のページ(users/signup.php)](http://localhost:8080/users/signup.php)
[トップページ(index.php)](http://localhost:8080/index.php)

## 作業詳細
サインアップ時のUserDaoの作成しました。
①Emailアドレスがデータベースに登録されていれば、登録されているユーザーの情報を配列で返す機能。
②パスワードをハッシュ化してから、Emailとパスワードを登録する機能。
<img width="380" alt="スクリーンショット 2023-06-02 21 14 50" src="https://github.com/takuya12345/kakeibo-ddd/assets/91111297/7a18d57b-ea6b-4935-a3c4-ab9fa6c1db8a">
能。

③遷移先のパスを修正しました。(トップページ：index.php)

## 気になる点・不安な点
特になし。