### PR TITLE
UseCaseの実装

### DIFF
--- a/src/app/Domain/ValueObject/User/AccrualDate.php
+++ b/src/app/Domain/ValueObject/User/AccrualDate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Domain\ValueObject\User;
+
+use Exception;
+/**
+ * ユーザーの名前用のValueObject
+ */
+final class AccrualDate
+{
+    /**
+     * ユーザーの名前が不正な場合のエラーメッセージ
+     */
+    const INVALID_MESSAGE = '日付を正しく入力してください。';
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * コンストラクタ
+     *
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+
+        if ($this->isInvalid($value)) {
+            throw new Exception(self::INVALID_MESSAGE);
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * バリデーションを通った値を返す
+     * 
+     * @return string
+     */
+    public function value() :string
+    {
+        return $this->value;
+    }
+
+    /**
+     * ユーザー名のバリデーション
+     *
+     * @param string $value
+     * @return bool
+     */
+    private function isInvalid(string $value): bool
+    {
+        // ここのバリデーションが分からない
+        return mb_strlen($value) > 20;
+    }
+}

--- a/src/app/Domain/ValueObject/User/AccrualDate.php
+++ b/src/app/Domain/ValueObject/User/AccrualDate.php
@@ -51,7 +51,9 @@ final class AccrualDate
      */
     private function isInvalid(string $value): bool
     {
-        // ここのバリデーションが分からない
-        return mb_strlen($value) > 20;
+        $preg = '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/';
+
+        // DB、spendingsテーブルのaccrual_dateカラムと正規表現が一致するかどうかの判定
+        return !preg_match($preg, $value);
     }
 }

--- a/src/app/Domain/ValueObject/User/CategoryId.php
+++ b/src/app/Domain/ValueObject/User/CategoryId.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Domain\ValueObject\User;
+
+use Exception;
+
+/**
+ * ユーザーの名前用のValueObject
+ */
+final class CategoryId
+{
+    /**
+     * カテゴリーIDが不正な場合のエラーメッセージ
+     */
+    const INVALID_MESSAGE = '不正な値です。';
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * コンストラクタ
+     *
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        if ($this->isInvalid($value)) {
+            throw new \Exception(self::INVALID_MESSAGE);
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * ユーザー名のバリデーション
+     *
+     * @param string $value
+     * @return boolean
+     */
+    private function isInvalid(string $value): bool
+    {
+        return mb_strlen($value) > 20;
+    }
+}

--- a/src/app/Domain/ValueObject/User/SpendingsAmount.php
+++ b/src/app/Domain/ValueObject/User/SpendingsAmount.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Domain\ValueObject\User;
+
+use Exception;
+/**
+ * ユーザーの名前用のValueObject
+ */
+final class SpendingsAmount
+{
+    /**
+     * ユーザーの名前が不正な場合のエラーメッセージ
+     */
+    const INVALID_MESSAGE = '1円以上の金額を入力してください。';
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * コンストラクタ
+     *
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        if ($this->isInvalid($value)) {
+            throw new Exception(self::INVALID_MESSAGE);
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * ユーザー名のバリデーション
+     *
+     * @param string $value
+     * @return boolean
+     */
+    private function isInvalid(string $value): bool
+    {
+        return $value < 1;
+    }
+}

--- a/src/app/Domain/ValueObject/User/UserId.php
+++ b/src/app/Domain/ValueObject/User/UserId.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Domain\ValueObject\User;
+
+use Exception;
+
+/**
+ * ユーザーの名前用のValueObject
+ */
+final class UserId
+{
+    /**
+     * ユーザーIDが不正な場合のエラーメッセージ
+     */
+    const MIN_VALUE = 1;
+    const INVALID_MESSAGE = '不正な値です。';
+
+    /**
+     * @var int
+     */
+    private $value;
+
+    /**
+     * コンストラクタ
+     *
+     * @param int $value
+     */
+    public function __construct(int $value)
+    {
+        if ($this->isInvalid($value)) {
+            throw new Exception(self::INVALID_MESSAGE);
+        }
+        $this->value = $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function value(): int
+    {
+        return $this->value;
+    }
+
+    /**
+     * ユーザー名のバリデーション
+     *
+     * @param int $value
+     * @return boolean
+     */
+    private function isInvalid(int $value): bool
+    {
+        return $value < self::MIN_VALUE;
+    }
+}

--- a/src/app/Domain/ValueObject/User/UserName.php
+++ b/src/app/Domain/ValueObject/User/UserName.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Domain\ValueObject\User;
+
+use Exception;
+
+/**
+ * ユーザーの名前用のValueObject
+ */
+final class UserName
+{
+    /**
+     * ユーザーの名前が不正な場合のエラーメッセージ
+     */
+    const INVALID_MESSAGE = 'ユーザー名は20文字以下でお願いします！';
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * コンストラクタ
+     *
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        if ($this->isInvalid($value)) {
+            throw new Exception(self::INVALID_MESSAGE);
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * ユーザー名のバリデーション
+     *
+     * @param string $value
+     * @return boolean
+     */
+    private function isInvalid(string $value): bool
+    {
+        return mb_strlen($value) > 20;
+    }
+}

--- a/src/app/Infrastructure/Redirect/Redirect.php
+++ b/src/app/Infrastructure/Redirect/Redirect.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Infrastructure\Redirect;
+
+/**
+ * リダイレクトを行うクラス
+ */
+final class Redirect
+{
+    /**
+     * 渡したパスにリダイレクトする
+     *
+     * @param string $path
+     * @return void
+     */
+    public static function handler(string $path): void
+    {
+        header('Location:' . $path);
+        exit();
+    }
+}

--- a/src/app/UseCase/CreateSpendings/UseCaseInput.php
+++ b/src/app/UseCase/CreateSpendings/UseCaseInput.php
@@ -1,0 +1,98 @@
+<?php
+namespace App\UseCase\CreateSpendings;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+use App\Domain\ValueObject\User\UserName;
+use App\Domain\ValueObject\User\UserId;
+use App\Domain\ValueObject\User\SpendingsAmount;
+use App\Domain\ValueObject\User\CategoryId;
+use App\Domain\ValueObject\User\AccrualDate;
+
+/**
+ * ユースケースの入力値
+ */
+final class UseCaseInput
+{
+    /**
+     * @var UserName
+     */
+    private $userName;
+
+    /**
+     * @var UserId
+     */
+    private $userId;
+
+    /**
+     * @var SpendingsAmount
+     */
+    private $spendingsAmount;
+
+    /**
+     * @var CategoryId
+     */
+    private $categoryId;
+
+    /**
+     * @var AccrualDate
+     */
+    private $accrualDate;
+
+    /**
+     * コンストラクタ
+     *
+     * @param UserName $userName
+     * @param UserId $userId
+     * @param SpendingsAmount $spendingsAmount
+     * @param CategoryId $categoryId
+     * @param AccurualDate $accrualDate
+     */
+    public function __construct(UserName $userName, UserId $userId, SpendingsAmount $spendingsAmount, CategoryId $categoryId, AccrualDate $accrualDate)
+    {
+        $this->userName = $userName;
+        $this->userId = $userId;
+        $this->spendingsAmount = $spendingsAmount;
+        $this->categoryId = $categoryId;
+        $this->accrualDate = $accrualDate;
+    }
+
+    /**
+     * @return UserName
+     */
+    public function userName(): UserName
+    {
+        return $this->userName;
+    }
+
+    /**
+     * @return UserId
+     */
+    public function userId(): UserId
+    {
+        return $this->userId;
+    }
+    /**
+     * @return SpendingsAmount
+     */
+    public function spendingsAmount(): SpendingsAmount
+    {
+        return $this->spendingsAmount;
+    }
+
+    /**
+     * @return CategoryId
+     */
+    public function categoryId(): CategoryId
+    {
+        return $this->categoryId;
+    }
+    
+    /**
+     * @return AccrualDate
+     */
+    public function accrualDate(): AccrualDate
+    {
+        return $this->accrualDate;
+    }
+}

--- a/src/app/UseCase/CreateSpendings/UseCaseInteractor.php
+++ b/src/app/UseCase/CreateSpendings/UseCaseInteractor.php
@@ -1,0 +1,78 @@
+<?php
+namespace App\UseCase\CreateSpendings;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+use App\Dao\SpendingDao;
+use App\UseCase\CreateSpendings\UseCaseInput;
+use App\UseCase\CreateSpendings\UseCaseOutput;
+
+/**
+ * ユースケースの入力値
+ */
+final class UseCaseInteractor
+{
+    /**
+     * 登録失敗時のメッセージ
+     */
+    const FAILED_MESSAGE = "登録内容が間違っています。";
+
+    /**
+     * 登録成功時のメッセージ
+     */
+    const SUCCESS_MESSAGE = "登録しました。";
+    
+    /**
+     * @var UseCaseInput
+     */
+    private $input;
+
+    /**
+     * @var SpendingDao
+     */
+    private $spendingDao;
+
+    /**
+     * コンストラクタ
+     *
+     * @param UseCaseInput $input
+     * @param SpendingDao $spendingDao
+     */
+    public function __construct(UseCaseInput $input, SpendingDao $spendingDao)
+    {
+        $this->input = $input;
+        $this->spendingDao = $spendingDao;
+    }
+
+    /**
+     * ユーザー登録処理
+     * すでに存在するメールアドレスの場合はエラーとする
+     *
+     * @return UseCaseOutput
+     */
+    public function handler(): UseCaseOutput
+    {
+        session_start();
+        $loginUserId = $_SESSION['user']['id'];
+        $registerUserId = $this->input->userId()->value();
+
+        if ($this->isCorrectUserId($loginUserId, $registerUserId)) {
+            return new UseCaseOutput(false, self::FAILED_MESSAGE);
+        }
+
+        $this->spendingDao->createSpendingSource($this->input->userName()->value(), $this->input->userId()->value(), $this->input->categoryId()->value(), $this->input->spendingsAmount()->value(), $this->input->accrualDate()->value());
+        return new UseCaseOutput(true, self::SUCCESS_MESSAGE);
+    }
+
+    /**
+     * ユーザーが存在するかどうか
+     *
+     * @param array|null $user
+     * @return boolean
+     */
+    private function isCorrectUserId(int $loginUserId, int $registerUserId): bool
+    {
+        return $loginUserId !== $registerUserId;
+    }
+
+}

--- a/src/app/UseCase/CreateSpendings/UseCaseOutput.php
+++ b/src/app/UseCase/CreateSpendings/UseCaseOutput.php
@@ -1,0 +1,50 @@
+<?php
+namespace App\UseCase\CreateSpendings;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+
+
+/**
+ * ユースケースの入力値
+ */
+final class UseCaseOutput
+{
+    /**
+     * @var bool
+     */
+    private $isSuccess;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * コンストラクタ
+     *
+     * @param boolean $isSuccess
+     * @param string $message
+     */
+    public function __construct(bool $isSuccess, string $message)
+    {
+        $this->isSuccess = $isSuccess;
+        $this->message = $message;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isSuccess(): bool
+    {
+        return $this->isSuccess;
+    }
+
+    /**
+     * @return string
+     */
+    public function message(): string
+    {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
## 作業対象
[支出登録処理のページ(spendings/create.php)](http://localhost:8080/spendings/create.php)

## 作業詳細
UseCaseの実装を行う。
入力内容のバリデーションを行い、入力内容が正しければ、登録処理に移る。
正しくなければ、入力内容をセッションに保存し、登録ページへリダイレクトさせる。

## 気になる点・不安な点
バリデーションのエラーメッセージが表示されていないと考えています。

スニペット（ https://github.dev/tech-quest/repository-queryservise-snippet ）のtry、catch文の36行目以降を見てもエラーを吐く処理がコーディングされていないと思うので、UseCaseでエラーメッセージを記載する必要がないでしょうか！？
あるいは、一旦UseCaseを使って登録の処理ができていれば、一旦OKという認識で合っていますか😅？